### PR TITLE
Catch premature cf options destruction.

### DIFF
--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -10,6 +10,7 @@
 
 #include "db/dbformat.h"
 #include "options/db_options.h"
+#include "port/stack_trace.h"
 #include "rocksdb/options.h"
 #include "util/compression.h"
 
@@ -21,8 +22,10 @@ struct CopyInstrumentation {
     if (is_copy) {
       (*copies)--;
     } else {
-      // TODO: print stacktrace
-      if (*copies != 0) printf("use after free detected\n");
+      if (*copies != 0) {
+        fprintf(stderr, "FATAL: ImmutableCFOptions destroyed before all copies.\n");
+        ROCKSDB_NAMESPACE::port::PrintStack();
+      }
     }
   }
   void AnnotateAsCopyOf(const CopyInstrumentation& other) const {

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -21,12 +21,12 @@ struct CopyInstrumentation {
     if (is_copy) {
       (*copies)--;
     } else {
+      // Crash whenever the original object is destroyed before all copies.
       assert(*copies == 0);
     }
   }
   CopyInstrumentation(const CopyInstrumentation &other) : copies(new int(0)), is_copy(false) {}
   CopyInstrumentation(const CopyInstrumentation &other, bool is_copy) : copies(other.copies), is_copy(true) {
-    // Crash whenever the original object is destroyed before all copies.
     assert(is_copy);
     (*copies)++;
   }

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -16,7 +16,7 @@
 namespace ROCKSDB_NAMESPACE {
 struct CopyInstrumentation {
   CopyInstrumentation() {}
-  explicit CopyInstrumentation(const CopyInstrumentation &other) {}
+  explicit CopyInstrumentation(const CopyInstrumentation&) {}
   ~CopyInstrumentation() {
     if (is_copy) {
       (*copies)--;

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -522,10 +522,14 @@ struct BlockBasedTable::Rep {
         global_seqno(kDisableGlobalSequenceNumber),
         file_size(_file_size),
         level(_level),
-        immortal_table(_immortal_table) {}
+        immortal_table(_immortal_table) {
+          ioptions.copy_instrumentation.copies = _ioptions.copy_instrumentation.copies;
+          (*ioptions.copy_instrumentation.copies)++;
+          ioptions.copy_instrumentation.is_copy = true;
+        }
   ~Rep() { status.PermitUncheckedError(); }
-  const ImmutableCFOptions& ioptions;
-  const EnvOptions& env_options;
+  ImmutableCFOptions ioptions;
+  const EnvOptions env_options;
   const BlockBasedTableOptions table_options;
   const FilterPolicy* const filter_policy;
   const InternalKeyComparator& internal_comparator;

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -523,12 +523,10 @@ struct BlockBasedTable::Rep {
         file_size(_file_size),
         level(_level),
         immortal_table(_immortal_table) {
-          ioptions.copy_instrumentation.copies = _ioptions.copy_instrumentation.copies;
-          (*ioptions.copy_instrumentation.copies)++;
-          ioptions.copy_instrumentation.is_copy = true;
+          ioptions.AnnotateAsCopyOf(_ioptions);
         }
   ~Rep() { status.PermitUncheckedError(); }
-  ImmutableCFOptions ioptions;
+  const ImmutableCFOptions ioptions;
   const EnvOptions env_options;
   const BlockBasedTableOptions table_options;
   const FilterPolicy* const filter_policy;


### PR DESCRIPTION
Crash when cf options is destructed before all the copies.